### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mcwiki.svg)](https://pypi.org/project/mcwiki/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-> A scraping library for the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Minecraft_Wiki).
+> A scraping library for the [Minecraft Wiki](https://minecraft.wiki/w/Minecraft_Wiki).
 
 ```python
 import mcwiki
@@ -56,7 +56,7 @@ $ pip install mcwiki
 The `load` function allows you to load a page from the Minecraft Wiki. The page can be specified by providing a URL or simply the title of the page.
 
 ```python
-mcwiki.load("https://minecraft.fandom.com/wiki/Data_Pack")
+mcwiki.load("https://minecraft.wiki/w/Data_Pack")
 mcwiki.load("Data Pack")
 ```
 
@@ -70,7 +70,7 @@ mcwiki.from_markup("<!DOCTYPE html>\n<html ...")
 Page sections can then be manipulated like dictionaries. Keys are case-insensitive and are associated to subsections.
 
 ```python
-page = mcwiki.load("https://minecraft.fandom.com/wiki/Advancement/JSON_format")
+page = mcwiki.load("https://minecraft.wiki/w/Advancement/JSON_format")
 
 print(page["List of triggers"])
 ```

--- a/mcwiki/page.py
+++ b/mcwiki/page.py
@@ -18,7 +18,7 @@ from bs4 import BeautifulSoup, PageElement, Tag
 from .extractor import Extractor, ScanResult
 from .utils import normalize_string
 
-BASE_URL = "https://minecraft.fandom.com/wiki/"
+BASE_URL = "https://minecraft.wiki/w/"
 
 
 def load(page: str) -> "PageSection":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,12 @@ def wiki_pages(request: pytest.FixtureRequest):
     directory.mkdir(exist_ok=True)
 
     download = {
-        "data_pack.html": "https://minecraft.fandom.com/wiki/Data_Pack",
-        "advancement.html": "https://minecraft.fandom.com/wiki/Advancement/JSON_format",
-        "loot_table.html": "https://minecraft.fandom.com/wiki/Loot_table",
-        "predicate.html": "https://minecraft.fandom.com/wiki/Predicate",
-        "tag.html": "https://minecraft.fandom.com/wiki/Tag",
-        "item_modifier.html": "https://minecraft.fandom.com/wiki/Item_modifier",
+        "data_pack.html": "https://minecraft.wiki/w/Data_Pack",
+        "advancement.html": "https://minecraft.wiki/w/Advancement/JSON_format",
+        "loot_table.html": "https://minecraft.wiki/w/Loot_table",
+        "predicate.html": "https://minecraft.wiki/w/Predicate",
+        "tag.html": "https://minecraft.wiki/w/Tag",
+        "item_modifier.html": "https://minecraft.wiki/w/Item_modifier",
     }
 
     for filename, url in download.items():


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki